### PR TITLE
Shuffle the calibration point array

### DIFF
--- a/calibration_screen.cpp
+++ b/calibration_screen.cpp
@@ -23,16 +23,18 @@ CalibrationScreen::CalibrationScreen(QWidget *parent) : QWidget(parent){
     points[7] = QPointF(0.5,0.9);
     points[8] = QPointF(0.9,0.9);
 
+    srand(time(NULL));
     timer = new QTimer(this);
     size = 50;
     connect(timer, SIGNAL(timeout()), this, SLOT(updatePosition()));
 }
 
 void CalibrationScreen::startCalibration(Tracker* selectedTracker){
+
     for(int i = 0; i < 9; i++)
     {
         QPointF tmp = points[i];
-        int j = QRandomGenerator::system()->bounded(i, 9);
+        int j = rand() % (9 - i) + i;
         points[i] = points[j];
         points[j] = tmp;
     }

--- a/calibration_screen.hpp
+++ b/calibration_screen.hpp
@@ -4,7 +4,8 @@
 #include <QWidget>
 #include <QPainter>
 #include <QTimer>
-#include <QRandomGenerator>
+#include <cstdlib>
+#include <ctime>
 #include "tracker.hpp"
 
 class CalibrationScreen : public QWidget {


### PR DESCRIPTION
The calibration goes through the array in order so shuffling the contents of the array randomizes the order points are traversed during calibration