### PR TITLE
Disable reticle checkbox while tracking

### DIFF
--- a/main_window.cpp
+++ b/main_window.cpp
@@ -67,6 +67,7 @@ void MainWindow::startTracker() {
         ui->startServerButton->setText("Start Tracker");
         trackerManager.stopTracking();
         app_state = IDLE;
+
         ui->reticleBox->setEnabled(true);
     }
 }


### PR DESCRIPTION
This pull request resolves issue #23.

As documented in the commit, this is a "feature" work around.
If a solution that allows for dynamic reticle enabling/disabling can be implemented, it should be used instead.