### PR TITLE
Get X,Y From GazePoint Tracker

### DIFF
--- a/itrace_core/GazeData.cs
+++ b/itrace_core/GazeData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using System.Xml;
 
 namespace iTrace_Core
 {
@@ -67,8 +68,20 @@ namespace iTrace_Core
         public GazepointGazeData(String gazePointRawGaze) : base()
         {
             foobar = gazePointRawGaze;
+            
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(gazePointRawGaze);
 
-            //TODO: initialize X and Y
+            XmlNode recNode = xmlDoc.FirstChild;
+            if(recNode.Attributes["BPOGX"] == null)
+            {
+                X = 0;
+                Y = 0;
+                return;
+            }
+            
+            X = Convert.ToInt32(float.Parse(recNode.Attributes["BPOGX"].Value) * Screen.PrimaryScreen.Bounds.Width);
+            Y = Convert.ToInt32(float.Parse(recNode.Attributes["BPOGY"].Value) * Screen.PrimaryScreen.Bounds.Height);
         }
     }
 

--- a/itrace_core/GazePointTracker.cs
+++ b/itrace_core/GazePointTracker.cs
@@ -102,8 +102,10 @@ namespace iTrace_Core
             while (!gazeData.Contains("<ACK ID=\"ENABLE_SEND_DATA\" STATE=\"0\" />"))
             {
                 gazeData = Reader.ReadLine();
-                //Console.WriteLine(gazeData);
-                GazeHandler.Instance.EnqueueGaze(new GazepointGazeData(gazeData));
+                if (!gazeData.Contains("<ACK ID=\"ENABLE_SEND_DATA\" STATE=\"1\" />"))
+                {
+                    GazeHandler.Instance.EnqueueGaze(new GazepointGazeData(gazeData));
+                }
             }
         }
     }


### PR DESCRIPTION
Reads the xml stream from the gaze point tracker and extracts the x, y. Defaults to 0,0 if  the right attributes aren't present.

Closes #52 