### PR TITLE
Changed Output Directory Textbox to use Courier New, and will shrink …

### DIFF
--- a/itrace_core/SessionSetupWindow.xaml
+++ b/itrace_core/SessionSetupWindow.xaml
@@ -18,7 +18,7 @@
             <TextBox x:Name="ParticipantID" Height="23" Canvas.Left="136" TextWrapping="Wrap" Canvas.Top="172" Width="172"/>
 
             <Label Content="Data Directory" Canvas.Left="23" Canvas.Top="228" Height="27" Width="103"/>
-            <TextBox x:Name="DataOutputDir" Height="23" Canvas.Left="136" Canvas.Top="232" Width="172" TextWrapping="NoWrap" IsReadOnly="true"  Foreground="{x:Static SystemColors.GrayTextBrush}" />
+            <TextBox x:Name="DataOutputDir" Height="23" Canvas.Left="136" Canvas.Top="232" Width="172" FontFamily="Courier New" TextWrapping="NoWrap" IsReadOnly="true"  Foreground="{x:Static SystemColors.GrayTextBrush}" />
             <Button x:Name="DirectoryBrowseButton" Content="Browse" Canvas.Left="313" Canvas.Top="234" Width="75" Click="DirectoryBrowseButton_Click"/>
 
             <Button x:Name="SaveButton" Content="Save" HorizontalAlignment="Left" VerticalAlignment="Top" Width="75" Canvas.Left="195" Canvas.Top="303" Click="SaveButton_Click"/>

--- a/itrace_core/SessionSetupWindow.xaml.cs
+++ b/itrace_core/SessionSetupWindow.xaml.cs
@@ -27,8 +27,24 @@ namespace iTrace_Core
 
             if (result == System.Windows.Forms.DialogResult.OK && !string.IsNullOrWhiteSpace(folderDialogue.SelectedPath))
             {
-                DataOutputDir.Text = folderDialogue.SelectedPath;
+                string path = folderDialogue.SelectedPath;
+                if (path.Length > 23)
+                {
+                    string[] folders = path.Split('\\');
+
+                    string path_begin = folders[0] + "\\...\\";
+                    string path_end = folders[folders.Length - 1];
+
+                    int i = folders.Length - 2;
+                    while ((path_begin + folders[i] + "\\" + path_end).Length <= 23)
+                    {
+                        path_end = folders[i] + "\\" + path_end;
+                    }
+                    path = path_begin + path_end;
+                }
+                DataOutputDir.Text = path;
             }
+            
         }
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
We changed the font of the Session Setup Data Output Directory Textbox to use Courier New. We then shrink the text down to fit within the monospaced textbox, using ellipses to shorten it.

This change seems to works on differently sized monitors.

Closes #117 