### PR TITLE
Add Setting For Monitor Selection

### DIFF
--- a/itrace_core/App.config
+++ b/itrace_core/App.config
@@ -18,6 +18,9 @@
       <setting name="websocket_port" serializeAs="String">
         <value>7007</value>
       </setting>
+      <setting name="calibration_monitor" serializeAs="String">
+        <value>0</value>
+      </setting>
     </iTrace_Core.Properties.Settings>
   </userSettings>
   </configuration>

--- a/itrace_core/CalibrationWindow.xaml.cs
+++ b/itrace_core/CalibrationWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
+using iTrace_Core.Properties;
 
 namespace iTrace_Core
 {
@@ -49,9 +50,11 @@ namespace iTrace_Core
         public CalibrationWindow()
         {
             InitializeComponent();
-            
-            Left = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Left;
-            Top = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Top;
+
+            System.Windows.Forms.Screen calibrationMonitor = System.Windows.Forms.Screen.AllScreens[Settings.Default.calibration_monitor];
+
+            Left = calibrationMonitor.Bounds.Left;
+            Top = calibrationMonitor.Bounds.Top;
         }
 
         private void WindowLoaded(object sender, RoutedEventArgs e)

--- a/itrace_core/GazeData.cs
+++ b/itrace_core/GazeData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using iTrace_Core.Properties;
+using System;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -96,25 +97,35 @@ namespace iTrace_Core
         {
             bool isLeftEyeValid = tobiiRawGaze.LeftEye.GazePoint.Validity == Tobii.Research.Validity.Valid;
             bool isRightEyeValid = tobiiRawGaze.RightEye.GazePoint.Validity == Tobii.Research.Validity.Valid;
+            Screen screen = Screen.AllScreens[Settings.Default.calibration_monitor];
+
+            RightX = tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.X * screen.Bounds.Width + screen.Bounds.Left;
+            RightY = tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.Y * screen.Bounds.Height + screen.Bounds.Top;
+            RightPupil = tobiiRawGaze.RightEye.Pupil.PupilDiameter;
+            RightValidation = Convert.ToInt32(isRightEyeValid);
+
+            LeftX = tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.X * screen.Bounds.Width + screen.Bounds.Left;
+            LeftY = tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.Y * screen.Bounds.Height + screen.Bounds.Top;
+            LeftPupil = tobiiRawGaze.LeftEye.Pupil.PupilDiameter;
+            LeftValidation = Convert.ToInt32(isLeftEyeValid);
 
             if (isLeftEyeValid && isRightEyeValid)
             {
-                double avgX = (tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.X + tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.X) / 2.0D;
-                double avgY = (tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.Y + tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.Y) / 2.0D;
+                double avgX = (RightX + LeftX) / 2.0D;
+                double avgY = (RightY + LeftY) / 2.0D;
 
-                X = Convert.ToInt32(avgX * Screen.PrimaryScreen.Bounds.Width);
-                Y = Convert.ToInt32(avgY * Screen.PrimaryScreen.Bounds.Height);
-
+                X = Convert.ToInt32(avgX);
+                Y = Convert.ToInt32(avgY);
             }
             else if (isLeftEyeValid)
             {
-                X = Convert.ToInt32(tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.X * Screen.PrimaryScreen.Bounds.Width);
-                Y = Convert.ToInt32(tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.Y * Screen.PrimaryScreen.Bounds.Height);
+                X = Convert.ToInt32(LeftX);
+                Y = Convert.ToInt32(LeftY);
             }
             else if (isRightEyeValid)
             {
-                X = Convert.ToInt32(tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.X * Screen.PrimaryScreen.Bounds.Width);
-                Y = Convert.ToInt32(tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.Y * Screen.PrimaryScreen.Bounds.Height);
+                X = Convert.ToInt32(RightX);
+                Y = Convert.ToInt32(RightY);
             }
             else
             {
@@ -122,17 +133,6 @@ namespace iTrace_Core
                 X = null;
                 Y = null;
             }
-
-            RightX = tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.X * Screen.PrimaryScreen.Bounds.Width;
-            RightY = tobiiRawGaze.RightEye.GazePoint.PositionOnDisplayArea.Y * Screen.PrimaryScreen.Bounds.Height;
-            RightPupil = tobiiRawGaze.RightEye.Pupil.PupilDiameter;
-            RightValidation = Convert.ToInt32(isRightEyeValid);
-
-            LeftX = tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.X * Screen.PrimaryScreen.Bounds.Width;
-            LeftY = tobiiRawGaze.LeftEye.GazePoint.PositionOnDisplayArea.Y * Screen.PrimaryScreen.Bounds.Height;
-            LeftPupil = tobiiRawGaze.LeftEye.Pupil.PupilDiameter;
-            LeftValidation = Convert.ToInt32(isLeftEyeValid);
-
             UserLeftX = tobiiRawGaze.LeftEye.GazeOrigin.PositionInUserCoordinates.X;
             UserLeftY = tobiiRawGaze.LeftEye.GazeOrigin.PositionInUserCoordinates.Y;
             UserLeftZ = tobiiRawGaze.LeftEye.GazeOrigin.PositionInUserCoordinates.Z;
@@ -179,17 +179,18 @@ namespace iTrace_Core
                 Y = null;
                 return;
             }
+            Screen screen = Screen.AllScreens[Settings.Default.calibration_monitor];
 
-            X = Convert.ToInt32(Double.Parse(recNode.Attributes["BPOGX"].Value) * Screen.PrimaryScreen.Bounds.Width);
-            Y = Convert.ToInt32(Double.Parse(recNode.Attributes["BPOGY"].Value) * Screen.PrimaryScreen.Bounds.Height);
+            X = Convert.ToInt32(Double.Parse(recNode.Attributes["BPOGX"].Value) * screen.Bounds.Width + screen.Bounds.Left);
+            Y = Convert.ToInt32(Double.Parse(recNode.Attributes["BPOGY"].Value) * screen.Bounds.Height + screen.Bounds.Top);
 
-            RightX = Double.Parse(recNode.Attributes["RPOGX"].Value) * Screen.PrimaryScreen.Bounds.Width;
-            RightY = Double.Parse(recNode.Attributes["RPOGY"].Value) * Screen.PrimaryScreen.Bounds.Height;
+            RightX = Double.Parse(recNode.Attributes["RPOGX"].Value) * screen.Bounds.Width + screen.Bounds.Left;
+            RightY = Double.Parse(recNode.Attributes["RPOGY"].Value) * screen.Bounds.Height + screen.Bounds.Top;
             RightPupil = Double.Parse(recNode.Attributes["RPD"].Value);
             RightValidation = Int32.Parse(recNode.Attributes["RPOGV"].Value);
 
-            LeftX = Double.Parse(recNode.Attributes["LPOGX"].Value) * Screen.PrimaryScreen.Bounds.Width;
-            LeftY = Double.Parse(recNode.Attributes["LPOGY"].Value) * Screen.PrimaryScreen.Bounds.Height;
+            LeftX = Double.Parse(recNode.Attributes["LPOGX"].Value) * screen.Bounds.Width + screen.Bounds.Left;
+            LeftY = Double.Parse(recNode.Attributes["LPOGY"].Value) * screen.Bounds.Height + screen.Bounds.Top;
             LeftPupil = Double.Parse(recNode.Attributes["LPD"].Value);
             LeftValidation = Int32.Parse(recNode.Attributes["LPOGV"].Value);
 

--- a/itrace_core/MainWindow.xaml.cs
+++ b/itrace_core/MainWindow.xaml.cs
@@ -56,7 +56,8 @@ namespace iTrace_Core
             settings = new List<Setting>()
             {
                 new Setting("socket_port") { Value = Settings.Default.socket_port.ToString() },
-                new Setting("websocket_port") { Value = Settings.Default.websocket_port.ToString() }
+                new Setting("websocket_port") { Value = Settings.Default.websocket_port.ToString() },
+                new Setting("calibration_monitor") { Value = Settings.Default.calibration_monitor.ToString() }
             };
 
             settingsDataGrid.ItemsSource = settings;
@@ -66,7 +67,8 @@ namespace iTrace_Core
         {
             int socketPort = 0;
             int websocketPort = 0;
-            if (! (int.TryParse(settings[0].Value, out socketPort) && int.TryParse(settings[1].Value, out websocketPort)) )
+            int calibrationMonitor = 0;
+            if (! (int.TryParse(settings[0].Value, out socketPort) && int.TryParse(settings[1].Value, out websocketPort) && int.TryParse(settings[2].Value, out calibrationMonitor)) )
             {
                 MessageBox.Show(Properties.Resources.PortValuesMustBeNumeric, Properties.Resources.InvalidPortValue, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
@@ -91,8 +93,14 @@ namespace iTrace_Core
                 return;
             }
 
+            if(! ((calibrationMonitor <= System.Windows.Forms.Screen.AllScreens.Length) && (calibrationMonitor > 0)) )
+            {
+                MessageBox.Show(Properties.Resources.MonitorIndexOutOfRange, Properties.Resources.MonitorIndexIncorrectValue, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
             Settings.Default.socket_port = Convert.ToInt32(settings[0].Value);
             Settings.Default.websocket_port = Convert.ToInt32(settings[1].Value);
+            Settings.Default.calibration_monitor = Convert.ToInt32(settings[2].Value);
             Settings.Default.Save();
         }
 

--- a/itrace_core/Properties/Resources.Designer.cs
+++ b/itrace_core/Properties/Resources.Designer.cs
@@ -142,6 +142,24 @@ namespace iTrace_Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid Monitor.
+        /// </summary>
+        public static string MonitorIndexIncorrectValue {
+            get {
+                return ResourceManager.GetString("MonitorIndexIncorrectValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected monitor must exist.
+        /// </summary>
+        public static string MonitorIndexOutOfRange {
+            get {
+                return ResourceManager.GetString("MonitorIndexOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Port values cannot be the same value!.
         /// </summary>
         public static string PortValuesCannotBeSameValue {

--- a/itrace_core/Properties/Resources.resx
+++ b/itrace_core/Properties/Resources.resx
@@ -144,6 +144,12 @@
   <data name="InvalidWebSocketPortValue" xml:space="preserve">
     <value>Invalid Websocket Port Value"</value>
   </data>
+  <data name="MonitorIndexIncorrectValue" xml:space="preserve">
+    <value>Invalid Monitor</value>
+  </data>
+  <data name="MonitorIndexOutOfRange" xml:space="preserve">
+    <value>Selected monitor must exist</value>
+  </data>
   <data name="PortValuesCannotBeSameValue" xml:space="preserve">
     <value>Port values cannot be the same value!</value>
   </data>

--- a/itrace_core/Properties/Settings.Designer.cs
+++ b/itrace_core/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace iTrace_Core.Properties {
                 this["websocket_port"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int calibration_monitor {
+            get {
+                return ((int)(this["calibration_monitor"]));
+            }
+            set {
+                this["calibration_monitor"] = value;
+            }
+        }
     }
 }

--- a/itrace_core/Properties/Settings.settings
+++ b/itrace_core/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="websocket_port" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">7007</Value>
     </Setting>
+    <Setting Name="calibration_monitor" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Added app setting for calibration window. This will allow the users to select which monitor their eye tracker is one.
Edited the gaze trackers to perform the calculation based on what monitor is being used and return gaze coordinates in the global windows coordinate systems.